### PR TITLE
new api for flv demuxer support pkt duration

### DIFF
--- a/libavformat/flvdec.c
+++ b/libavformat/flvdec.c
@@ -56,7 +56,7 @@ typedef struct FLVContext {
     int searched_for_end;
     //add by teddy.ma for flv demuxer, video pkt duration
     int trust_pkt_duration;
-    int video_pkt_duration;
+    int64_t video_pkt_duration;
 } FLVContext;
 
 static int probe(AVProbeData *p, int live)

--- a/libavformat/flvdec.c
+++ b/libavformat/flvdec.c
@@ -56,7 +56,7 @@ typedef struct FLVContext {
     int searched_for_end;
     //add by teddy.ma for flv demuxer, video pkt duration
     int trust_pkt_duration;
-    int64_t video_pkt_duration;
+    int video_pkt_duration;
 } FLVContext;
 
 static int probe(AVProbeData *p, int live)


### PR DESCRIPTION
Root Cause: ffmpeg flv demuxer do not support video pkt duration lead ijkplayer check buffering logic is overflow when do flv streaming playback.
Solution: add a option, use valid first pts(non zero) as video pkt duration